### PR TITLE
chore: Sync CI from template repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 99
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 99

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,41 @@
+name: Link Check
+
+on:
+  pull_request:
+    paths:
+    - ".github/workflows/link-check.yml"
+    - ".markdown-link-check.json"
+    - "link-check.js"
+    - "package*.json"
+    - "**/*.md"
+
+  push:
+    branches-ignore:
+    - "dependabot/**"
+    paths:
+    - ".github/workflows/link-check.yml"
+    - ".markdown-link-check.json"
+    - "link-check.js"
+    - "package*.json"
+    - "**/*.md"
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2.1.1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Run link checks
+        run: npm run link-check

--- a/.github/workflows/markdownlint-problem-matcher.json
+++ b/.github/workflows/markdownlint-problem-matcher.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "markdownlint",
+            "pattern": [
+                {
+                    "regexp": "^([^:]*):(\\d+):?(\\d+)?\\s([\\w-\\/]*)\\s(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "code": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,43 @@
+name: Markdownlint
+
+on:
+  pull_request:
+    paths:
+    - ".github/workflows/markdownlint-problem-matcher.json"
+    - ".github/workflows/markdownlint.yml"
+    - ".markdownlint.json"
+    - "package*.json"
+    - "**/*.md"
+
+  push:
+    branches-ignore:
+    - "dependabot/**"
+    paths:
+    - ".github/workflows/markdownlint-problem-matcher.json"
+    - ".github/workflows/markdownlint.yml"
+    - ".markdownlint.json"
+    - "package*.json"
+    - "**/*.md"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2.1.1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Run Markdownlint
+        run: |
+          echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
+          npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-
-node_js:
-- "node"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/canada-ca/template-gabarit.svg?branch=master)](https://travis-ci.org/canada-ca/template-gabarit)
-
 ([Français](#gabarit-pour-dépôts-de-code-source-ouvert-du-gouvernement-du-canada))
 
 ## Guidance on Secure Containers and Microservices


### PR DESCRIPTION
Synced in changes from the template repo:
- Switched Travis to GitHub actions for better targeting of test runs based on changed files
- Add the explicit/new Dependabot config. This won't auto-land PRs anymore, but that is the intention from GH for security propagation reasons
